### PR TITLE
Django 1.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,11 +4,10 @@ Changelog for django-x509
 0.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Django 1.8 compatibility
 
 
 0.1 (2014-04-10)
 ----------------
 
 - Initial commit.
-

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,5 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
         packages=['x509'],
         include_package_data=True,
         zip_safe=False,
-        install_requires=['setuptools>=1.1.6', 'flask', 'django-uuidfield',
-                          'pyOpenSSL'],
-        entry_points={
-            'console_scripts': [
-                'test_app = x509.test_app:main',
-            ]
-        }
+        install_requires=['pyOpenSSL'],
     )

--- a/x509/django/compat.py
+++ b/x509/django/compat.py
@@ -1,0 +1,10 @@
+try:
+    from django.db.models import UUIDField
+except ImportError:
+    # Django < 1.8
+    try:
+        from uuidfield import UUIDField
+    except ImportError:
+        raise ImportError("In order to use django-x509 with Django < 1.8 you "
+                          "must install django-uuidfield.")
+    

--- a/x509/django/models.py
+++ b/x509/django/models.py
@@ -2,7 +2,8 @@
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
 from django.db import models
-from uuidfield import UUIDField
+
+from x509.django.compat import UUIDField
 
 
 class Certificate(models.Model):

--- a/x509/django/views.py
+++ b/x509/django/views.py
@@ -11,7 +11,6 @@ class PEMFormView(FormView):
 
     def form_valid(self, form):
         certificate = form.get_certificate()
-        print certificate
         return HttpResponse('%s as been imported.'
                             '<a href=".">Add another one</a>.' % certificate)
 


### PR DESCRIPTION
As discussed, this PR drops Django 1.7 support as we use Django's UUIDField instead of django-uuidfield.

cc @toopy @bersace  