### PR TITLE
Add migrations for Django models

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ Changelog for django-x509
 0.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add migrations for Django models. Fix Django 1.8 error.
 
 
 0.2 (2015-11-24)

--- a/x509/django/migrations/0001_initial.py
+++ b/x509/django/migrations/0001_initial.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Certificate',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('serial', models.UUIDField(unique=True)),
+                ('dn', models.TextField(verbose_name=b'Distinguished Name')),
+                ('created_at', models.DateTimeField(null=True, blank=True)),
+                ('expire_at', models.DateTimeField(null=True, blank=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='GenericCertificateM2M',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('object_id', models.PositiveIntegerField()),
+                ('certificate', models.ForeignKey(related_name='attachees', to='django.Certificate')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+            ],
+        ),
+    ]


### PR DESCRIPTION
When using this app with Django 1.8, you can have migrations issues.

Django 1.8 adds migrations for `django.contrib.contenttypes`.  As models from apps without migrations are created first, `GenericCertificateM2M` creation fails because it tries to add a FK with `ContentType` which doesn't exist yet.

Adding the initial migration for the app works.

cc @toopy @bersace 